### PR TITLE
Get full related elements from way or relations v2

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,20 +38,21 @@
     -   [fetchMapByBbox][34]
     -   [deleteElement][35]
 -   [fetchElementRequest][36]
--   [fetchWaysForNodeRequest][37]
--   [sendElementRequest][38]
--   [fetchNotesRequest][39]
--   [createChangesetRequest][40]
--   [changesetCheckRequest][41]
--   [fetchMapByBbox][42]
--   [deleteElementRequest][43]
--   [fetchRelationsForElementRequest][44]
+-   [fetchElementRequestFull][37]
+-   [fetchWaysForNodeRequest][38]
+-   [sendElementRequest][39]
+-   [fetchNotesRequest][40]
+-   [createChangesetRequest][41]
+-   [changesetCheckRequest][42]
+-   [fetchMapByBbox][43]
+-   [deleteElementRequest][44]
+-   [fetchRelationsForElementRequest][45]
 
 ## getCurrentIsoTimestamp
 
 Get the current timestamp (for testing purpose)
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## removeTrailingSlashes
 
@@ -59,9 +60,9 @@ Remove the trailing slashes from an URL and return it
 
 **Parameters**
 
--   `url` **[string][45]** 
+-   `url` **[string][46]** 
 
-Returns **[string][45]** The cleaned URL
+Returns **[string][46]** The cleaned URL
 
 ## simpleObjectDeepClone
 
@@ -77,9 +78,9 @@ All the objects contained in the items array will be references to the first obj
 
 **Parameters**
 
--   `object` **[Object][46]** A simple object notation. No Map, Set or anything
+-   `object` **[Object][47]** A simple object notation. No Map, Set or anything
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
 
 ## findElementType
 
@@ -87,9 +88,9 @@ Return the type of an element based on the full OSM ID
 
 **Parameters**
 
--   `osmId` **[string][45]** 
+-   `osmId` **[string][46]** 
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## findElementId
 
@@ -97,17 +98,17 @@ Return the ID of an element based on the full OSM ID
 
 **Parameters**
 
--   `osmId` **[string][45]** 
+-   `osmId` **[string][46]** 
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## buildQueryString
 
 **Parameters**
 
--   `params` **[Object][46]** 
+-   `params` **[Object][47]** 
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## encodeXML
 
@@ -115,9 +116,9 @@ Escape a string to make it XML parameter-safe
 
 **Parameters**
 
--   `str` **[string][45]**  (optional, default `''`)
+-   `str` **[string][46]**  (optional, default `''`)
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## buildChangesetXml
 
@@ -125,10 +126,10 @@ Build a stringified OSM changeset
 
 **Parameters**
 
--   `createdBy` **[string][45]?**  (optional, default `''`)
--   `comment` **[string][45]?**  (optional, default `''`)
+-   `createdBy` **[string][46]?**  (optional, default `''`)
+-   `comment` **[string][46]?**  (optional, default `''`)
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## convertElementXmlToJson
 
@@ -136,11 +137,11 @@ Convert a raw Element API response into a well formatted JSON object
 
 **Parameters**
 
--   `xml` **[string][45]** The raw API response
--   `elementType` **[string][45]** The type of the concerned OSM element (eg: node, way, relation)
--   `elementId` **[string][45]** The ID of the concerned OSM element
+-   `xml` **[string][46]** The raw API response
+-   `elementType` **[string][46]** The type of the concerned OSM element (eg: node, way, relation)
+-   `elementId` **[string][46]** The ID of the concerned OSM element
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## cleanWaysJsonFragment
 
@@ -148,10 +149,10 @@ Convert a JSON list of ways fragment into a well formatted JSON object
 
 **Parameters**
 
--   `wayKey` **[Object][46]** The raw API response
--   `rootOsmMetadata` **[Object][46]** The raw API response
+-   `wayKey` **[Object][47]** The raw API response
+-   `rootOsmMetadata` **[Object][47]** The raw API response
 
-Returns **[Array][48]** 
+Returns **[Array][49]** 
 
 ## cleanMapJson
 
@@ -159,9 +160,9 @@ Convert a JSON object with OSM map features into a well formatted JSON object
 
 **Parameters**
 
--   `osmMapJson` **[Object][46]** The raw API response
+-   `osmMapJson` **[Object][47]** The raw API response
 
-Returns **[Array][48]** 
+Returns **[Array][49]** 
 
 ## convertWaysXmlToJson
 
@@ -169,9 +170,9 @@ Convert a raw list of ways API response into a well formatted JSON object
 
 **Parameters**
 
--   `xml` **[string][45]** The raw API response
+-   `xml` **[string][46]** The raw API response
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## convertRelationsXmlToJson
 
@@ -179,9 +180,9 @@ Convert list of relations into a well formatted JSON object
 
 **Parameters**
 
--   `xml` **[string][45]** The raw API response
+-   `xml` **[string][46]** The raw API response
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## convertNotesXmlToJson
 
@@ -189,9 +190,9 @@ Convert a raw Notes API response into a well formatted JSON object
 
 **Parameters**
 
--   `xml` **[string][45]** The raw API response
+-   `xml` **[string][46]** The raw API response
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## flattenAttributes
 
@@ -217,9 +218,9 @@ Eg:
 
 **Parameters**
 
--   `object` **[Object][46]** 
+-   `object` **[Object][47]** 
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
 
 ## xmlToJson
 
@@ -227,9 +228,9 @@ Convert a stringified XML into a JSON object
 
 **Parameters**
 
--   `xml` **[string][45]** 
+-   `xml` **[string][46]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## jsonToXml
 
@@ -237,9 +238,9 @@ Convert a JSON object into a stringified XML
 
 **Parameters**
 
--   `json` **[Object][46]** 
+-   `json` **[Object][47]** 
 
-Returns **[string][45]** 
+Returns **[string][46]** 
 
 ## OsmRequest
 
@@ -247,13 +248,13 @@ OSM API request handler
 
 **Parameters**
 
--   `options` **[Object][46]?** Custom options to apply (optional, default `{}`)
+-   `options` **[Object][47]?** Custom options to apply (optional, default `{}`)
 
 ### endpoint
 
 Return the API endpoint to use for the requests
 
-Returns **[string][45]** URL of the API endpoint
+Returns **[string][46]** URL of the API endpoint
 
 ### fetchNotes
 
@@ -261,14 +262,14 @@ Retrieve the OSM notes in given bounding box
 
 **Parameters**
 
--   `left` **[number][49]** The minimal longitude (X)
--   `bottom` **[number][49]** The minimal latitude (Y)
--   `right` **[number][49]** The maximal longitude (X)
--   `top` **[number][49]** The maximal latitude (Y)
--   `limit` **[number][49]?** The maximal amount of notes to retrieve (between 1 and 10000, defaults to 100) (optional, default `null`)
--   `closedDays` **[number][49]?** The amount of days a note needs to be closed to no longer be returned (defaults to 7, 0 means only opened notes are returned, and -1 means all notes are returned) (optional, default `null`)
+-   `left` **[number][50]** The minimal longitude (X)
+-   `bottom` **[number][50]** The minimal latitude (Y)
+-   `right` **[number][50]** The maximal longitude (X)
+-   `top` **[number][50]** The maximal latitude (Y)
+-   `limit` **[number][50]?** The maximal amount of notes to retrieve (between 1 and 10000, defaults to 100) (optional, default `null`)
+-   `closedDays` **[number][50]?** The amount of days a note needs to be closed to no longer be returned (defaults to 7, 0 means only opened notes are returned, and -1 means all notes are returned) (optional, default `null`)
 
-Returns **[Promise][47]** Resolves on notes list
+Returns **[Promise][48]** Resolves on notes list
 
 ### createChangeset
 
@@ -276,10 +277,10 @@ Send a request to OSM to create a new changeset
 
 **Parameters**
 
--   `createdBy` **[string][45]?**  (optional, default `''`)
--   `comment` **[string][45]?**  (optional, default `''`)
+-   `createdBy` **[string][46]?**  (optional, default `''`)
+-   `comment` **[string][46]?**  (optional, default `''`)
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### isChangesetStillOpen
 
@@ -287,9 +288,9 @@ Check if a changeset is still open
 
 **Parameters**
 
--   `changesetId` **[number][49]** 
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### createNodeElement
 
@@ -297,21 +298,23 @@ Create a shiny new OSM node element, in a JSON format
 
 **Parameters**
 
--   `lat` **[number][49]** 
--   `lon` **[number][49]** 
--   `properties` **[Object][46]?** Optional, initial properties (optional, default `{}`)
+-   `lat` **[number][50]** 
+-   `lon` **[number][50]** 
+-   `properties` **[Object][47]?** Optional, initial properties (optional, default `{}`)
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
 
 ### fetchElement
 
-Fetch an OSM element by its ID
+Fetch an OSM element by its ID and optionnally
+all other elements referenced by it
 
 **Parameters**
 
--   `osmId` **[string][45]** Eg: node/12345
+-   `osmId` **[string][46]** Eg: node/12345
+-   `options` **[Object][47]** Can be {full: true}
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### fetchRelationsForElement
 
@@ -319,9 +322,9 @@ Fetch relation(s) from an OSM element
 
 **Parameters**
 
--   `osmId` **[string][45]** Eg: node/12345
+-   `osmId` **[string][46]** Eg: node/12345
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### fetchWaysForNode
 
@@ -329,9 +332,9 @@ Fetch ways using the given OSM node
 
 **Parameters**
 
--   `osmId` **[string][45]** Eg: node/12345
+-   `osmId` **[string][46]** Eg: node/12345
 
-Returns **[Promise][47]** Resolve on ways array (each one can be used as an Element for all other functions)
+Returns **[Promise][48]** Resolve on ways array (each one can be used as an Element for all other functions)
 
 ### setProperty
 
@@ -339,11 +342,11 @@ Add or replace a property in a given element
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `propertyName` **[string][45]** 
--   `propertyValue` **[string][45]** 
+-   `element` **[Object][47]** 
+-   `propertyName` **[string][46]** 
+-   `propertyValue` **[string][46]** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### setProperties
 
@@ -351,10 +354,10 @@ Add or replace several properties in a given element
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `properties` **[Object][46]** 
+-   `element` **[Object][47]** 
+-   `properties` **[Object][47]** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### removeProperty
 
@@ -362,10 +365,10 @@ Remove a property from a given element
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `propertyName` **[string][45]** 
+-   `element` **[Object][47]** 
+-   `propertyName` **[string][46]** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### setCoordinates
 
@@ -373,11 +376,11 @@ Replace the coordinates of the OSM node and return a copy of the element
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `lat` **[number][49]** 
--   `lon` **[number][49]** 
+-   `element` **[Object][47]** 
+-   `lat` **[number][50]** 
+-   `lon` **[number][50]** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### setTimestampToNow
 
@@ -385,9 +388,9 @@ Set the current UTC date to a given element
 
 **Parameters**
 
--   `element` **[Object][46]** 
+-   `element` **[Object][47]** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### setVersion
 
@@ -395,10 +398,10 @@ Change the version number (given by API) of an element
 
 **Parameters**
 
--   `element` **[Object][46]** 
+-   `element` **[Object][47]** 
 -   `version` **int** 
 
-Returns **[Object][46]** A new version of the element
+Returns **[Object][47]** A new version of the element
 
 ### sendElement
 
@@ -406,10 +409,10 @@ Send an element to OSM
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `changesetId` **[number][49]** 
+-   `element` **[Object][47]** 
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### fetchMapByBbox
 
@@ -417,12 +420,12 @@ Request to fetch all OSM elements within a bbox extent
 
 **Parameters**
 
--   `left` **[number][49]** The minimal longitude (X)
--   `bottom` **[number][49]** The minimal latitude (Y)
--   `right` **[number][49]** The maximal longitude (X)
--   `top` **[number][49]** The maximal latitude (Y)
+-   `left` **[number][50]** The minimal longitude (X)
+-   `bottom` **[number][50]** The minimal latitude (Y)
+-   `right` **[number][50]** The maximal longitude (X)
+-   `top` **[number][50]** The maximal latitude (Y)
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ### deleteElement
 
@@ -430,10 +433,10 @@ Delete an element from OSM
 
 **Parameters**
 
--   `element` **[Object][46]** 
--   `changesetId` **[number][49]** 
+-   `element` **[Object][47]** 
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** Promise with the new version number due to deletion
+Returns **[Promise][48]** Promise with the new version number due to deletion
 
 ## fetchElementRequest
 
@@ -441,10 +444,21 @@ Request to fetch an OSM element
 
 **Parameters**
 
--   `endpoint` **[string][45]** The API endpoint
--   `osmId` **[string][45]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `osmId` **[string][46]** 
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
+
+## fetchElementRequestFull
+
+Request to fetch way or relation and all other elements referenced by it
+
+**Parameters**
+
+-   `endpoint` **[string][46]** The API endpoint
+-   `osmId` **[string][46]** Can only contain either a way or a relation
+
+Returns **[Promise][48]** Promise with well formatted JSON content
 
 ## fetchWaysForNodeRequest
 
@@ -452,10 +466,10 @@ Request to fetch ways using the given OSM node
 
 **Parameters**
 
--   `endpoint` **[string][45]** The API endpoint
--   `osmId` **[string][45]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `osmId` **[string][46]** 
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
 
 ## sendElementRequest
 
@@ -464,11 +478,11 @@ Send an element to OSM
 **Parameters**
 
 -   `auth` **osmAuth** An instance of osm-auth
--   `endpoint` **[string][45]** The API endpoint
--   `element` **[Object][46]** 
--   `changesetId` **[number][49]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `element` **[Object][47]** 
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## fetchNotesRequest
 
@@ -476,15 +490,15 @@ Request to fetch OSM notes
 
 **Parameters**
 
--   `endpoint` **[string][45]** The API endpoint
--   `left` **[number][49]** The minimal longitude (X)
--   `bottom` **[number][49]** The minimal latitude (Y)
--   `right` **[number][49]** The maximal longitude (X)
--   `top` **[number][49]** The maximal latitude (Y)
--   `limit` **[number][49]?** The maximal amount of notes to retrieve (between 1 and 10000, defaults to 100) (optional, default `null`)
--   `closedDays` **[number][49]?** The amount of days a note needs to be closed to no longer be returned (defaults to 7, 0 means only opened notes are returned, and -1 means all notes are returned) (optional, default `null`)
+-   `endpoint` **[string][46]** The API endpoint
+-   `left` **[number][50]** The minimal longitude (X)
+-   `bottom` **[number][50]** The minimal latitude (Y)
+-   `right` **[number][50]** The maximal longitude (X)
+-   `top` **[number][50]** The maximal latitude (Y)
+-   `limit` **[number][50]?** The maximal amount of notes to retrieve (between 1 and 10000, defaults to 100) (optional, default `null`)
+-   `closedDays` **[number][50]?** The amount of days a note needs to be closed to no longer be returned (defaults to 7, 0 means only opened notes are returned, and -1 means all notes are returned) (optional, default `null`)
 
-Returns **[Object][46]** 
+Returns **[Object][47]** 
 
 ## createChangesetRequest
 
@@ -493,11 +507,11 @@ Request to create OSM changesets
 **Parameters**
 
 -   `auth` **osmAuth** An instance of osm-auth
--   `endpoint` **[string][45]** The API endpoint
--   `createdBy` **[string][45]?**  (optional, default `''`)
--   `comment` **[string][45]?**  (optional, default `''`)
+-   `endpoint` **[string][46]** The API endpoint
+-   `createdBy` **[string][46]?**  (optional, default `''`)
+-   `comment` **[string][46]?**  (optional, default `''`)
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## changesetCheckRequest
 
@@ -506,10 +520,10 @@ Checks if a given changeset is still opened at OSM.
 **Parameters**
 
 -   `auth` **osmAuth** An instance of osm-auth
--   `endpoint` **[string][45]** The API endpoint
--   `changesetId` **[number][49]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## fetchMapByBbox
 
@@ -517,13 +531,13 @@ Request to fetch all OSM elements within a bbox extent
 
 **Parameters**
 
--   `endpoint` **[string][45]** The API endpoint
--   `left` **[number][49]** The minimal longitude (X)
--   `bottom` **[number][49]** The minimal latitude (Y)
--   `right` **[number][49]** The maximal longitude (X)
--   `top` **[number][49]** The maximal latitude (Y)
+-   `endpoint` **[string][46]** The API endpoint
+-   `left` **[number][50]** The minimal longitude (X)
+-   `bottom` **[number][50]** The minimal latitude (Y)
+-   `right` **[number][50]** The maximal longitude (X)
+-   `top` **[number][50]** The maximal latitude (Y)
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 ## deleteElementRequest
 
@@ -532,11 +546,11 @@ Delete an OSM element
 **Parameters**
 
 -   `auth` **osmAuth** An instance of osm-auth
--   `endpoint` **[string][45]** The API endpoint
--   `element` **[Object][46]** 
--   `changesetId` **[number][49]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `element` **[Object][47]** 
+-   `changesetId` **[number][50]** 
 
-Returns **[Promise][47]** Promise with the new version number due to deletion
+Returns **[Promise][48]** Promise with the new version number due to deletion
 
 ## fetchRelationsForElementRequest
 
@@ -544,10 +558,10 @@ Request to fetch relation(s) from an OSM element
 
 **Parameters**
 
--   `endpoint` **[string][45]** The API endpoint
--   `osmId` **[string][45]** 
+-   `endpoint` **[string][46]** The API endpoint
+-   `osmId` **[string][46]** 
 
-Returns **[Promise][47]** 
+Returns **[Promise][48]** 
 
 [1]: #getcurrentisotimestamp
 
@@ -621,28 +635,30 @@ Returns **[Promise][47]**
 
 [36]: #fetchelementrequest
 
-[37]: #fetchwaysfornoderequest
+[37]: #fetchelementrequestfull
 
-[38]: #sendelementrequest
+[38]: #fetchwaysfornoderequest
 
-[39]: #fetchnotesrequest
+[39]: #sendelementrequest
 
-[40]: #createchangesetrequest
+[40]: #fetchnotesrequest
 
-[41]: #changesetcheckrequest
+[41]: #createchangesetrequest
 
-[42]: #fetchmapbybbox-1
+[42]: #changesetcheckrequest
 
-[43]: #deleteelementrequest
+[43]: #fetchmapbybbox-1
 
-[44]: #fetchrelationsforelementrequest
+[44]: #deleteelementrequest
 
-[45]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[45]: #fetchrelationsforelementrequest
 
-[46]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[46]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[47]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[47]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[48]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[48]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[49]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[49]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[50]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number

--- a/API.md
+++ b/API.md
@@ -312,7 +312,8 @@ all other elements referenced by it
 **Parameters**
 
 -   `osmId` **[string][46]** Eg: node/12345
--   `options` **[Object][47]** Can be {full: true}
+-   `options` **[Object][47]** Optional parameters
+    -   `options.full` **[boolean][51]?** True for getting all elements referenced by this element
 
 Returns **[Promise][48]** 
 
@@ -662,3 +663,5 @@ Returns **[Promise][48]**
 [49]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [50]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[51]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean

--- a/src/helpers/xml.js
+++ b/src/helpers/xml.js
@@ -95,15 +95,18 @@ export function cleanMapJson(osmMapJson) {
       };
     });
   }
-  return {
+  const newOsmObject = {
     osm: {
       $,
-      bounds,
       node,
       way,
       relation
     }
   };
+  if (bounds) {
+    newOsmObject.osm.bounds = bounds;
+  }
+  return newOsmObject;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,8 @@ export default class OsmRequest {
    * Fetch an OSM element by its ID and optionnally
    * all other elements referenced by it
    * @param {string} osmId Eg: node/12345
-   * @param {Object} options Can be {full: true}
+   * @param {Object} options  Optional parameters
+   * @param {boolean} [options.full] True for getting all elements referenced by this element
    * @return {Promise}
    */
   fetchElement(osmId, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { getCurrentIsoTimestamp } from 'helpers/time';
 import { removeTrailingSlashes, simpleObjectDeepClone } from 'helpers/utils';
 import {
   fetchElementRequest,
+  fetchElementRequestFull,
   fetchMapByBbox,
   fetchRelationsForElementRequest,
   fetchWaysForNodeRequest,
@@ -129,12 +130,18 @@ export default class OsmRequest {
   }
 
   /**
-   * Fetch an OSM element by its ID
+   * Fetch an OSM element by its ID and optionnally
+   * all other elements referenced by it
    * @param {string} osmId Eg: node/12345
+   * @param {Object} options Can be {full: true}
    * @return {Promise}
    */
-  fetchElement(osmId) {
-    return fetchElementRequest(this.endpoint, osmId);
+  fetchElement(osmId, options) {
+    if (options && options.full) {
+      return fetchElementRequestFull(this.endpoint, osmId);
+    } else {
+      return fetchElementRequest(this.endpoint, osmId);
+    }
   }
 
   /**

--- a/src/requests.js
+++ b/src/requests.js
@@ -35,6 +35,26 @@ export function fetchElementRequest(endpoint, osmId) {
 }
 
 /**
+ * Request to fetch way or relation and all other elements referenced by it
+ * @param {string} endpoint The API endpoint
+ * @param {string} osmId Can only contain either a way or a relation
+ * @return {Promise} Promise with well formatted JSON content
+ */
+export function fetchElementRequestFull(endpoint, osmId) {
+  return fetch(`${endpoint}/api/0.6/${osmId}/full`)
+    .then(response => response.text())
+    .then(response => {
+      return xmlToJson(response)
+        .then(json => {
+          return Promise.resolve(cleanMapJson(json));
+        })
+        .catch(error => {
+          throw new RequestException(error);
+        });
+    });
+}
+
+/**
  * Request to fetch ways using the given OSM node
  * @param {string} endpoint The API endpoint
  * @param {string} osmId


### PR DESCRIPTION
Integrate the ability to fetch an OSM element by its ID and all other elements referenced by it (https://wiki.openstreetmap.org/wiki/API_v0.6#Full:_GET_.2Fapi.2F0.6.2F.5Bway.7Crelation.5D.2F.23id.2Ffull) instead of only the OSM element.
Changed has been done to modify `fetchElement` due to discussion in #4.
This PR replaces #4.

Need review